### PR TITLE
fix: uses-rel-preload

### DIFF
--- a/src/Shared/MainLayout.razor
+++ b/src/Shared/MainLayout.razor
@@ -7,7 +7,7 @@
 
     <main>
         <div class="top-row px-4">
-            <a href="https://docs.microsoft.com/aspnet/" target="_blank">About</a>
+            <a href="https://docs.microsoft.com/aspnet/" target="_blank" rel="noopener">About</a>
         </div>
 
         <article class="content px-4">

--- a/src/Shared/SurveyPrompt.razor
+++ b/src/Shared/SurveyPrompt.razor
@@ -4,7 +4,7 @@
 
     <span class="text-nowrap">
         Please take our
-        <a target="_blank" class="font-weight-bold link-dark" href="https://go.microsoft.com/fwlink/?linkid=2148851">brief survey</a>
+        <a target="_blank" rel="noopener" class="font-weight-bold link-dark" href="https://go.microsoft.com/fwlink/?linkid=2148851">brief survey</a>
     </span>
     and tell us what you think.
 </div>


### PR DESCRIPTION
Add rel="noopener" attribute to all <a> tags that contain the target="_blank" attribute 
but not the rel="noopener" or rel="noreferrer" attributes.


https://github.com/kaiwanyawit-chawankul/test-lighthouse-ci/issues/1